### PR TITLE
rspec core no longer sends _exception param

### DIFF
--- a/lib/spec_upon_a_time/formatter.rb
+++ b/lib/spec_upon_a_time/formatter.rb
@@ -18,7 +18,7 @@ module SpecUponATime
                  :pending)
     end
 
-    def failure_output(example, _exception)
+    def failure_output(example, _exception=nil)
       codes.wrap("#{current_indentation}#{example.description.strip} " \
                  "(#{run_time_for(example)}) " \
                  "(FAILED - #{next_failure_index})",


### PR DESCRIPTION
See https://github.com/rspec/rspec-core/commit/227e7cae419eee104764a8c9cfbf20b911cb63aa

For spec_upon_a_time to be compatible with the latest rspec versions, the failure_output method needs to be tolerant to being called with only one parameter.
